### PR TITLE
Error returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Update the link to API docs in README.md
 
+### Fixed
+* Return errors (e.g. connection, ZAP API) with a rejected promise.
+
 ## [2.0.0-rc.1] - 2023-05-19
 ### Added
 * Add the API of the following add-ons:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ let response = await zaproxy.spider.scanAsUser(params);
 console.log(response);
 ```
 
+### Encountering Errors
+
+When encountering an error, like attempting to retrieve a non-existent context, a rejected promise will be returned. The rejection will contain an `ApiClientError` object, which encapsulates the specific details of the original error. This `ApiClientError` object offers valuable information regarding the failed request, and the original error can be accessed through the `cause` property. The response details, if any, are available through the `response` property, containing the `status` and `data` (body).
+
 ## API
 
 For a full API list, see [https://www.zaproxy.org/docs/api/](https://www.zaproxy.org/docs/api/).

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,17 @@ function ClientApi (options) {
   this.websocket = new Websocket(this)
 }
 
+class ApiClientError extends Error {
+  constructor (err) {
+    super(err.message, { cause: err })
+    this.name = 'ApiClientError'
+    this.response = {
+      status: err.response?.status,
+      data: err.response?.data
+    }
+  }
+}
+
 ClientApi.prototype.request = async (url, data, format) => {
   try {
     let requestConfig = structuredClone(defaultAxiosConfig)
@@ -122,7 +133,7 @@ ClientApi.prototype.request = async (url, data, format) => {
 
     return response.data
   } catch (error) {
-    console.log(error.message, ', Data:', error.response?.data)
+    return Promise.reject(new ApiClientError(error))
   }
 }
 


### PR DESCRIPTION
Hey,
I started using your npm package today for my custom built API. I want to be able to return a somewhat meaningful error message to the user of my API whenever there is an error, but with your implementation, the error only gets logged into the console and there is no way of retrieving it. I did some changes to implement this. All you need is pass a option paramater when creating new ZapClient. I also added an option to enable/disable error logging in console.

Would it be pease possible to merge these changes so I can use these new features ? Thanks in advance !

Erik