### PR TITLE
Allow to call the API with custom HTTP method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+* Allow to call the ZAP API with custom HTTP method (e.g. file upload).
 
 ## [2.0.0-rc.3] - 2023-10-14
 ### Changed

--- a/src/index.js
+++ b/src/index.js
@@ -120,16 +120,23 @@ class ApiClientError extends Error {
   }
 }
 
-ClientApi.prototype.request = async (url, data, format) => {
+ClientApi.prototype.request = async (url, data, format, method = 'GET') => {
   try {
     let requestConfig = structuredClone(defaultAxiosConfig)
+    requestConfig.method = method
+    requestConfig.url = url
     if (data) {
-      requestConfig.params = { ...requestConfig.params, ...data }
+      if (method === 'GET') {
+        requestConfig.params = data
+      } else {
+        requestConfig.headers = { ...requestConfig.headers, ...{ 'content-type': 'application/x-www-form-urlencoded' } }
+        requestConfig.data = data
+      }
     }
     if (format === 'other') {
       requestConfig = { ...requestConfig, baseURL: BASE_URL_OTHER }
     }
-    const response = await axios.get(url, requestConfig)
+    const response = await axios.request(requestConfig)
 
     return response.data
   } catch (error) {


### PR DESCRIPTION
Change the request function to allow to specify the method, if not GET the parameters are sent in the body.